### PR TITLE
Add support for more TFC Run Statuses

### DIFF
--- a/internal/provider/resource_run.go
+++ b/internal/provider/resource_run.go
@@ -184,10 +184,16 @@ RETRY:
 		tfe.RunPlanned,
 		tfe.RunPlannedAndFinished,
 		tfe.RunErrored,
+		tfe.RunCostEstimated,
+		tfe.RunPolicyChecked,
+		tfe.RunPolicyOverride,
+		tfe.RunPolicySoftFailed,
 	}, []tfe.RunStatus{
 		tfe.RunPending,
 		tfe.RunPlanQueued,
 		tfe.RunPlanning,
+		tfe.RunCostEstimating,
+		tfe.RunPolicyChecking,
 	})
 	if diags != nil {
 		return diags

--- a/internal/provider/resource_run.go
+++ b/internal/provider/resource_run.go
@@ -187,6 +187,7 @@ RETRY:
 		tfe.RunCostEstimated,
 		tfe.RunPolicyChecked,
 		tfe.RunPolicySoftFailed,
+		tfe.RunPolicyOverride,
 	}, []tfe.RunStatus{
 		tfe.RunPending,
 		tfe.RunPlanQueued,
@@ -199,7 +200,7 @@ RETRY:
 	}
 
 	// If the run errored, we should have exited already but lets just exit now.
-	if run.Status == tfe.RunErrored {
+	if run.Status == tfe.RunErrored || run.Status == tfe.RunPolicySoftFailed {
 		// Clear the ID, we didn't create anything.
 		setId("")
 
@@ -221,7 +222,7 @@ RETRY:
 	}
 
 	// If a policy soft-fails, we need human approval before we continue
-	if run.Status == tfe.RunPolicySoftFailed {
+	if run.Status == tfe.RunPolicyOverride {
 		log.Printf("[INFO] policy check soft-failed, waiting for manual override. %q", run.ID)
 		run, diags = waitForRun(ctx, client, org, run, ws, true, []tfe.RunStatus{
 			tfe.RunPolicyOverride,

--- a/internal/provider/resource_run.go
+++ b/internal/provider/resource_run.go
@@ -225,7 +225,9 @@ RETRY:
 	if run.Status == tfe.RunPolicyOverride {
 		log.Printf("[INFO] policy check soft-failed, waiting for manual override. %q", run.ID)
 		run, diags = waitForRun(ctx, client, org, run, ws, true, []tfe.RunStatus{
-			tfe.RunPolicyOverride,
+			tfe.RunConfirmed,
+			tfe.RunApplyQueued,
+			tfe.RunApplying,
 		}, []tfe.RunStatus{run.Status})
 		if diags != nil {
 			return diags


### PR DESCRIPTION
Fix for https://github.com/mitchellh/terraform-provider-multispace/issues/3

From my (manual) tests (see comments on https://github.com/lucymhdavies/terraform-provider-multispace/commit/d44e04b4899f69655a2d6e6dc2b6c69d76799542) it handles the missing states well.

When a workspace enters tfe.RunPolicyOverride state, then the provider is unable to start an apply with the current version of the code.

This makes sense, considering the provider attempts an "Apply" not an "Override":

```
		// Apply the plan.
		log.Printf("[INFO] plan complete, confirming apply. %q", run.ID)
		if err := client.Runs.Apply(ctx, run.ID, tfe.RunApplyOptions{
```

As such, in these cases, the provider stops and waits for manual override.